### PR TITLE
FIX: 타임존 False를 하여 csv_to_db를 할 때에 datetime에러 해결

### DIFF
--- a/madup/settings.py
+++ b/madup/settings.py
@@ -116,7 +116,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ O ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
DB 저장 에러 해소

<br />

## :: 구현 사항 설명
db_uploader.py에서 전체 79858행 중 1500개가 누락되었음. 에러를 확인하니 TIMEZONE과 관련된 에러라고 하여,
django TZ=False로 변경하여 해결하였음. 



<br />

## :: ISSUE


<br />